### PR TITLE
Add orbit plotter

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "web-vitals": "^1.0.1"
   },
   "scripts": {
-    "start": "cross-env REACT_APP_GIT_SHA=$(123) react-scripts start",
+    "start": "cross-env REACT_APP_GIT_SHA=$(git describe) react-scripts start",
     "build": "cross-env REACT_APP_GIT_SHA=$(git describe) react-scripts build",
     "build:ci": "cross-env CI=true yarn build",
     "build:localhost": "cross-env PUBLIC_URL='.' react-scripts build",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "web-vitals": "^1.0.1"
   },
   "scripts": {
-    "start": "cross-env REACT_APP_GIT_SHA=$(git describe) react-scripts start",
+    "start": "cross-env REACT_APP_GIT_SHA=$(123) react-scripts start",
     "build": "cross-env REACT_APP_GIT_SHA=$(git describe) react-scripts build",
     "build:ci": "cross-env CI=true yarn build",
     "build:localhost": "cross-env PUBLIC_URL='.' react-scripts build",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -26,6 +26,7 @@ import ServiceWorkerWrapper from './components/ServiceWorkerWrapper';
 import SettingsProvider, { SettingsContext } from './components/settings/SettingsContext';
 import SettingsMenu from './components/settings/SettingsMenu';
 import theme from './theme/theme';
+import OrbitPlotter from './components/orbit_plotter/OrbitPlotter';
 
 function App(): JSX.Element {
   const size = useWindowSize();
@@ -145,6 +146,20 @@ function App(): JSX.Element {
                 <CoordinateInterface
                   show={settings.showCoordinates}
                   mandelbrot={mandelbrotControls}
+                />
+                <OrbitPlotter
+                  show={settings.showOrbit}
+                  mandelbrot={mandelbrotControls}
+                  rendererWidth={
+                    (size.width || 1) < (size.height || 0)
+                      ? size.width || 1
+                      : (size.width || 1) / 2
+                  }
+                  rendererHeight={
+                    (size.width || 1) < (size.height || 0)
+                      ? (size.height || 0) / 2
+                      : size.height || 0
+                  }
                 />
                 <Grid item xs className="renderer">
                   <MandelbrotRenderer controls={mandelbrotControls} {...settings} />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -147,20 +147,22 @@ function App(): JSX.Element {
                   show={settings.showCoordinates}
                   mandelbrot={mandelbrotControls}
                 />
-                <OrbitPlotter
-                  show={settings.showOrbit}
-                  mandelbrot={mandelbrotControls}
-                  rendererWidth={
-                    (size.width || 1) < (size.height || 0)
-                      ? size.width || 1
-                      : (size.width || 1) / 2
-                  }
-                  rendererHeight={
-                    (size.width || 1) < (size.height || 0)
-                      ? (size.height || 0) / 2
-                      : size.height || 0
-                  }
-                />
+                {settings.showOrbit ? (
+                  <OrbitPlotter
+                    show={settings.showOrbit}
+                    mandelbrot={mandelbrotControls}
+                    rendererWidth={
+                      (size.width || 1) < (size.height || 0)
+                        ? size.width || 1
+                        : (size.width || 1) / 2
+                    }
+                    rendererHeight={
+                      (size.width || 1) < (size.height || 0)
+                        ? (size.height || 0) / 2
+                        : size.height || 0
+                    }
+                  />
+                ) : null}
                 <Grid item xs className="renderer">
                   <MandelbrotRenderer controls={mandelbrotControls} {...settings} />
                 </Grid>

--- a/src/common/complex_number_helper.ts
+++ b/src/common/complex_number_helper.ts
@@ -25,6 +25,7 @@ export const forwardOrbit = function (
 ): [orbit: XYType[], prePeriod: number, period: number] {
   const orbit = [];
   for (let i = 0; i < maxIterations; i++) {
+    // eslint-disable-next-line no-loop-func
     const similar = orbit.findIndex((elem) => approximatelyEqual(elem, z));
     if (similar !== -1) {
       return [orbit, similar, i - similar];

--- a/src/common/complex_number_helper.ts
+++ b/src/common/complex_number_helper.ts
@@ -1,0 +1,335 @@
+import { XYType } from '../common/types';
+
+const TOLERANCE = 0.001;
+const FLOATING_POINT_TOLERANCE = 0.01;
+export const MAX_DEPTH = 4;
+
+export function magnitude(p: XYType): number {
+  return Math.sqrt(p[0] * p[0] + p[1] * p[1]);
+}
+
+export const distance = (a: XYType, b: XYType) => {
+  return Math.sqrt(Math.pow(a[0] - b[0], 2) + Math.pow(a[1] - b[1], 2));
+};
+
+const add = function (a: XYType, b: XYType): XYType {
+  return [a[0] + b[0], a[1] + b[1]];
+};
+
+const sub = function (a: XYType, b: XYType): XYType {
+  return [a[0] - b[0], a[1] - b[1]];
+};
+
+export const mult = function (a: XYType, b: XYType): XYType {
+  return [a[0] * b[0] - a[1] * b[1], a[0] * b[1] + a[1] * b[0]];
+};
+
+const divide = function (x: XYType, y: XYType): XYType {
+  const d = Math.pow(y[0], 2) + Math.pow(y[1], 2);
+  return [(x[0] * y[0] + x[1] * y[1]) / d, (x[1] * y[0] - x[0] * y[1]) / d];
+};
+
+const square = (c: XYType): XYType => {
+  return [Math.pow(c[0], 2) - Math.pow(c[1], 2), 2.0 * c[0] * c[1]];
+};
+
+const sqrt = (c: XYType): XYType => {
+  const theta = Math.atan2(c[1], c[0]);
+  const r2 = Math.sqrt(magnitude(c));
+  return [r2 * Math.cos(theta / 2), r2 * Math.sin(theta / 2)];
+};
+
+export function complexNumbersEqual(a: XYType, b: XYType): boolean {
+  return a[0] === b[0] && a[1] === b[1];
+}
+
+export const preImagePositive = function (z: XYType, c: XYType): XYType {
+  return sqrt(sub(z, c));
+};
+
+export const preImageNegative = function (z: XYType, c: XYType): XYType {
+  return mult([-1, 0], sqrt(sub(z, c)));
+};
+
+export const orbit = function (z: XYType, c: XYType, t: number): XYType {
+  for (let i = 0; i < t; i++) {
+    z = add(square(z), c);
+  }
+  return z;
+};
+
+export const orbitList = function (
+  z: XYType,
+  c: XYType,
+  maxIterations: number,
+): [XYType[], number, number] {
+  const points = [];
+  for (let i = 0; i < maxIterations; i++) {
+    const similar = points.findIndex((elem) => distance(elem, z) < TOLERANCE);
+    if (similar !== -1) {
+      // we've hit a cycle
+      return [points, similar, i - similar];
+    }
+    points.push(z);
+    z = add(square(z), c);
+  }
+  return [points, -1, -1];
+};
+
+/**
+ * Take the derivative of f sub c with respect to z
+ *
+ * This value depends not on z per se., but the orbit of z.
+ *
+ * @param z - The point we're taking the derivative w.r.t
+ * @param c - The fixed constant +c of iteration
+ * @param t - How many iterations to go for
+ * @returns The derivative of W at c
+ */
+export const orbitEigenvalue = function (z: XYType, c: XYType, t: number): XYType {
+  let der: XYType = [1, 0];
+  for (let i = 0; i < t; i++) {
+    der = mult([2, 0], mult(der, z));
+    z = add(square(z), c);
+  }
+
+  return der;
+};
+
+/**
+ * Find the preperiod of a given point under iteration. This assumes it is preperiodic
+ *
+ * @param c - The point
+ * @returns If it's preperiodic: the preperiod, if it's periodic: nonsense, otherwise: -1.
+ */
+export const prePeriod = (z: XYType, c: XYType): number => {
+  const olds: XYType[] = [];
+  for (let i = 0; i < 50; i++) {
+    olds.push(z);
+    const newZ: XYType = add(square(z), c);
+    const similar = olds.findIndex((elem) => distance(elem, newZ) < TOLERANCE);
+    if (similar !== -1) return similar;
+
+    z = newZ;
+  }
+  return -1;
+};
+
+/**
+ * Find the period of a given point.
+ *
+ * @param z - The point
+ * @param c - The constant of iteration
+ * @returns The period, otherwise: -1.
+ */
+export const period = (z: XYType, c: XYType): number => {
+  const olds: XYType[] = [];
+  for (let i = 0; i < 50; i++) {
+    olds.push(z);
+    const newZ: XYType = add(square(z), c);
+    const similar = olds.findIndex((elem) => distance(elem, newZ) < TOLERANCE);
+    if (similar !== -1) {
+      // we've hit a cycle
+      return i - similar + 1;
+    }
+    z = newZ;
+  }
+  return -1;
+};
+
+/**
+ * Subtract the first iterate in a cycle from the last.
+ *
+ * @param c - The point we care about. Must be periodic or preperiodic
+ * @param z - The preperiod of c
+ * @param l - The period of c
+ * @returns The derivative of W at c
+ */
+const W = function (c: XYType, l: number, p: number) {
+  const endOfCycle = orbit(c, c, l + p);
+  const startOfCycle = orbit(c, c, l);
+
+  return sub(endOfCycle, startOfCycle);
+};
+
+/**
+ * Finds the numerical derivative of a function.
+ *
+ * @param c - The point we are taking the derivative of
+ * @returns The derivative of f at c
+ */
+const numericalDerivative = function (c: XYType, f: (c: XYType) => XYType): XYType {
+  const h = 1e-9;
+  const withoutH = f(c);
+  const withH = f(add(c, [h, 0]));
+
+  return [sub(withH, withoutH)[0] / h, sub(withH, withoutH)[1] / h];
+};
+
+export const cycleEigenvalue = (c: XYType, l: number, p: number) => {
+  const firstIterateInCycle: XYType = orbit(c, c, l);
+  return orbitEigenvalue(firstIterateInCycle, c, p);
+};
+
+/**
+ *
+ * @param c - The point at the centre of the branch
+ * @param l - The preperiod of c
+ * @param p - The period of z
+ * @returns The size of the branch
+ */
+export const magnificationRotationMandelbrot = function (
+  c: XYType,
+  l: number,
+  p: number,
+): XYType {
+  const firstIterateInCycle: XYType = orbit(c, c, l);
+  const cycleEigenvalue: XYType = orbitEigenvalue(firstIterateInCycle, c, p);
+
+  return divide(
+    numericalDerivative(c, (x: XYType) => W(x, l, p)),
+    sub(cycleEigenvalue, [1, 0]),
+  );
+};
+
+/**
+ * the point where zero enters a cycle
+ *
+ * @param c - The point
+ * @returns If it's preperiodic: the preperiod, if it's periodic: nonsense, otherwise: -1.
+ */
+export const getAlpha = (z: XYType, c: XYType): XYType => {
+  const olds: XYType[] = [];
+  for (let i = 0; i < 50; i++) {
+    olds.push(z);
+    const newZ: XYType = add(square(z), c);
+    const similar = olds.findIndex((elem) => distance(elem, newZ) < TOLERANCE);
+    if (similar !== -1) return newZ;
+
+    z = newZ;
+  }
+  return [-7, -7];
+};
+
+export const reachAlpha = function (c: XYType, z: XYType): number {
+  const alpha = getAlpha([0, 0], c);
+  for (let i = 0; i < 50; i++) {
+    if (distance(alpha, z) < TOLERANCE) return i;
+    z = add(square(z), c);
+  }
+  return -1;
+};
+
+export const magnificationRotationJulia = function (
+  c: XYType,
+  z: XYType,
+  q: number,
+): XYType {
+  return orbitEigenvalue(z, c, reachAlpha(c, z));
+};
+
+export function round(value: number, precision: number): number {
+  const multiplier = Math.pow(10, precision || 0);
+  return Math.round(value * multiplier) / multiplier;
+}
+
+export function formatComplexNumber(c: XYType): string {
+  return `${round(c[0], 3)}${c[1] >= 0 ? '+' : ''}${round(c[1], 3)}i`;
+}
+
+export function formatAngle(angle: number): string {
+  return `${round((180 / Math.PI) * angle, 0)}°`;
+}
+
+function findPotentialPreperiod(c: XYType): number {
+  let z: XYType = c;
+  let minNumber = 4;
+  let minp = -1;
+  for (let i = 0; i < 50; i++) {
+    const newZ: XYType = add(square(z), c);
+    const x = sub(newZ, z);
+    if (magnitude(x) < minNumber) {
+      minNumber = magnitude(x);
+      minp = i;
+    }
+    z = newZ;
+  }
+  return minp;
+}
+
+const Wfried = function (c: XYType, l: number, p: number) {
+  const endOfCycle = orbitEigenvalue(c, c, l + p);
+  const startOfCycle = orbitEigenvalue(c, c, l);
+
+  return sub(endOfCycle, startOfCycle);
+};
+
+export const findNearestMisiurewiczPoint = function (c: XYType): XYType {
+  const q = findPotentialPreperiod(c);
+  const p = 1;
+  const learningRate: XYType = [0.01, 0];
+  for (let i = 0; i < 1000; i++) {
+    const F = W(c, q, p);
+    const Fdash = Wfried(c, q, p);
+    c = sub(c, mult(learningRate, divide(F, Fdash)));
+  }
+  return c;
+};
+
+const depthFirstSearch = (z: XYType, c: XYType, zs: XYType[], depth: number) => {
+  zs.push(z);
+  if (distance(z, c) > FLOATING_POINT_TOLERANCE && depth > 0) {
+    depthFirstSearch(preImagePositive(z, c), c, zs, depth - 1);
+    depthFirstSearch(preImageNegative(z, c), c, zs, depth - 1);
+  }
+  return zs;
+};
+
+export const similarPoints = (c: PreperiodicPoint): PreperiodicPoint[] => {
+  const zs: XYType[] = [];
+
+  for (let i = c.prePeriod; i < c.prePeriod + c.period; i++) {
+    const z = orbit(c.point, c.point, i);
+    zs.push(z);
+    depthFirstSearch(mult([-1, 0], z), c.point, zs, MAX_DEPTH);
+  }
+  return zs.map((p) => new PreperiodicPoint(c.point, p));
+};
+
+const subscripts = ['₀', '₁', '₂', '₃', '₄', '₅', '₆', '₇', '₈', '₉'];
+export class PreperiodicPoint {
+  point: XYType;
+  c: XYType;
+  u: XYType;
+  a: XYType;
+  prePeriod: number;
+  period: number;
+  uMagnitude: number;
+  uAngle: number;
+  aMagnitude: number;
+  aAngle: number;
+
+  constructor(c: XYType, z: XYType) {
+    this.point = z;
+    this.c = c;
+
+    this.prePeriod = prePeriod(this.point, c);
+    this.period = period(this.point, c);
+
+    this.u = magnificationRotationMandelbrot(c, this.prePeriod, this.period);
+    this.uMagnitude = magnitude(this.u);
+    this.uAngle = Math.atan2(this.u[1], this.u[0]);
+
+    this.a = magnificationRotationJulia(c, this.point, this.prePeriod);
+    this.aMagnitude = magnitude(this.a);
+    this.aAngle = Math.atan2(this.a[1], this.a[0]);
+  }
+
+  toString(): string {
+    let pre = `M${this.prePeriod},${this.period}`;
+    for (let i = 0; i < 10; i++) {
+      pre = pre.replaceAll(i.toString(), subscripts[i]);
+    }
+    return pre;
+  }
+}

--- a/src/common/complex_number_helper.ts
+++ b/src/common/complex_number_helper.ts
@@ -1,335 +1,45 @@
 import { XYType } from '../common/types';
 
 const TOLERANCE = 0.001;
-const FLOATING_POINT_TOLERANCE = 0.01;
-export const MAX_DEPTH = 4;
 
-export function magnitude(p: XYType): number {
-  return Math.sqrt(p[0] * p[0] + p[1] * p[1]);
-}
-
-export const distance = (a: XYType, b: XYType) => {
+const distance = (a: XYType, b: XYType): number => {
   return Math.sqrt(Math.pow(a[0] - b[0], 2) + Math.pow(a[1] - b[1], 2));
+};
+
+const approximatelyEqual = (a: XYType, b: XYType): boolean => {
+  return distance(a, b) < TOLERANCE;
 };
 
 const add = function (a: XYType, b: XYType): XYType {
   return [a[0] + b[0], a[1] + b[1]];
 };
 
-const sub = function (a: XYType, b: XYType): XYType {
-  return [a[0] - b[0], a[1] - b[1]];
-};
-
-export const mult = function (a: XYType, b: XYType): XYType {
-  return [a[0] * b[0] - a[1] * b[1], a[0] * b[1] + a[1] * b[0]];
-};
-
-const divide = function (x: XYType, y: XYType): XYType {
-  const d = Math.pow(y[0], 2) + Math.pow(y[1], 2);
-  return [(x[0] * y[0] + x[1] * y[1]) / d, (x[1] * y[0] - x[0] * y[1]) / d];
-};
-
 const square = (c: XYType): XYType => {
   return [Math.pow(c[0], 2) - Math.pow(c[1], 2), 2.0 * c[0] * c[1]];
 };
 
-const sqrt = (c: XYType): XYType => {
-  const theta = Math.atan2(c[1], c[0]);
-  const r2 = Math.sqrt(magnitude(c));
-  return [r2 * Math.cos(theta / 2), r2 * Math.sin(theta / 2)];
-};
-
-export function complexNumbersEqual(a: XYType, b: XYType): boolean {
-  return a[0] === b[0] && a[1] === b[1];
-}
-
-export const preImagePositive = function (z: XYType, c: XYType): XYType {
-  return sqrt(sub(z, c));
-};
-
-export const preImageNegative = function (z: XYType, c: XYType): XYType {
-  return mult([-1, 0], sqrt(sub(z, c)));
-};
-
-export const orbit = function (z: XYType, c: XYType, t: number): XYType {
-  for (let i = 0; i < t; i++) {
-    z = add(square(z), c);
-  }
-  return z;
-};
-
-export const orbitList = function (
+export const forwardOrbit = function (
   z: XYType,
   c: XYType,
   maxIterations: number,
-): [XYType[], number, number] {
-  const points = [];
+): [orbit: XYType[], prePeriod: number, period: number] {
+  const orbit = [];
   for (let i = 0; i < maxIterations; i++) {
-    const similar = points.findIndex((elem) => distance(elem, z) < TOLERANCE);
+    const similar = orbit.findIndex((elem) => approximatelyEqual(elem, z));
     if (similar !== -1) {
-      // we've hit a cycle
-      return [points, similar, i - similar];
+      return [orbit, similar, i - similar];
     }
-    points.push(z);
+    orbit.push(z);
     z = add(square(z), c);
   }
-  return [points, -1, -1];
+  return [orbit, -1, -1];
 };
 
-/**
- * Take the derivative of f sub c with respect to z
- *
- * This value depends not on z per se., but the orbit of z.
- *
- * @param z - The point we're taking the derivative w.r.t
- * @param c - The fixed constant +c of iteration
- * @param t - How many iterations to go for
- * @returns The derivative of W at c
- */
-export const orbitEigenvalue = function (z: XYType, c: XYType, t: number): XYType {
-  let der: XYType = [1, 0];
-  for (let i = 0; i < t; i++) {
-    der = mult([2, 0], mult(der, z));
-    z = add(square(z), c);
-  }
-
-  return der;
-};
-
-/**
- * Find the preperiod of a given point under iteration. This assumes it is preperiodic
- *
- * @param c - The point
- * @returns If it's preperiodic: the preperiod, if it's periodic: nonsense, otherwise: -1.
- */
-export const prePeriod = (z: XYType, c: XYType): number => {
-  const olds: XYType[] = [];
-  for (let i = 0; i < 50; i++) {
-    olds.push(z);
-    const newZ: XYType = add(square(z), c);
-    const similar = olds.findIndex((elem) => distance(elem, newZ) < TOLERANCE);
-    if (similar !== -1) return similar;
-
-    z = newZ;
-  }
-  return -1;
-};
-
-/**
- * Find the period of a given point.
- *
- * @param z - The point
- * @param c - The constant of iteration
- * @returns The period, otherwise: -1.
- */
-export const period = (z: XYType, c: XYType): number => {
-  const olds: XYType[] = [];
-  for (let i = 0; i < 50; i++) {
-    olds.push(z);
-    const newZ: XYType = add(square(z), c);
-    const similar = olds.findIndex((elem) => distance(elem, newZ) < TOLERANCE);
-    if (similar !== -1) {
-      // we've hit a cycle
-      return i - similar + 1;
-    }
-    z = newZ;
-  }
-  return -1;
-};
-
-/**
- * Subtract the first iterate in a cycle from the last.
- *
- * @param c - The point we care about. Must be periodic or preperiodic
- * @param z - The preperiod of c
- * @param l - The period of c
- * @returns The derivative of W at c
- */
-const W = function (c: XYType, l: number, p: number) {
-  const endOfCycle = orbit(c, c, l + p);
-  const startOfCycle = orbit(c, c, l);
-
-  return sub(endOfCycle, startOfCycle);
-};
-
-/**
- * Finds the numerical derivative of a function.
- *
- * @param c - The point we are taking the derivative of
- * @returns The derivative of f at c
- */
-const numericalDerivative = function (c: XYType, f: (c: XYType) => XYType): XYType {
-  const h = 1e-9;
-  const withoutH = f(c);
-  const withH = f(add(c, [h, 0]));
-
-  return [sub(withH, withoutH)[0] / h, sub(withH, withoutH)[1] / h];
-};
-
-export const cycleEigenvalue = (c: XYType, l: number, p: number) => {
-  const firstIterateInCycle: XYType = orbit(c, c, l);
-  return orbitEigenvalue(firstIterateInCycle, c, p);
-};
-
-/**
- *
- * @param c - The point at the centre of the branch
- * @param l - The preperiod of c
- * @param p - The period of z
- * @returns The size of the branch
- */
-export const magnificationRotationMandelbrot = function (
-  c: XYType,
-  l: number,
-  p: number,
-): XYType {
-  const firstIterateInCycle: XYType = orbit(c, c, l);
-  const cycleEigenvalue: XYType = orbitEigenvalue(firstIterateInCycle, c, p);
-
-  return divide(
-    numericalDerivative(c, (x: XYType) => W(x, l, p)),
-    sub(cycleEigenvalue, [1, 0]),
-  );
-};
-
-/**
- * the point where zero enters a cycle
- *
- * @param c - The point
- * @returns If it's preperiodic: the preperiod, if it's periodic: nonsense, otherwise: -1.
- */
-export const getAlpha = (z: XYType, c: XYType): XYType => {
-  const olds: XYType[] = [];
-  for (let i = 0; i < 50; i++) {
-    olds.push(z);
-    const newZ: XYType = add(square(z), c);
-    const similar = olds.findIndex((elem) => distance(elem, newZ) < TOLERANCE);
-    if (similar !== -1) return newZ;
-
-    z = newZ;
-  }
-  return [-7, -7];
-};
-
-export const reachAlpha = function (c: XYType, z: XYType): number {
-  const alpha = getAlpha([0, 0], c);
-  for (let i = 0; i < 50; i++) {
-    if (distance(alpha, z) < TOLERANCE) return i;
-    z = add(square(z), c);
-  }
-  return -1;
-};
-
-export const magnificationRotationJulia = function (
-  c: XYType,
-  z: XYType,
-  q: number,
-): XYType {
-  return orbitEigenvalue(z, c, reachAlpha(c, z));
-};
-
-export function round(value: number, precision: number): number {
+function round(value: number, precision: number): number {
   const multiplier = Math.pow(10, precision || 0);
   return Math.round(value * multiplier) / multiplier;
 }
 
 export function formatComplexNumber(c: XYType): string {
   return `${round(c[0], 3)}${c[1] >= 0 ? '+' : ''}${round(c[1], 3)}i`;
-}
-
-export function formatAngle(angle: number): string {
-  return `${round((180 / Math.PI) * angle, 0)}°`;
-}
-
-function findPotentialPreperiod(c: XYType): number {
-  let z: XYType = c;
-  let minNumber = 4;
-  let minp = -1;
-  for (let i = 0; i < 50; i++) {
-    const newZ: XYType = add(square(z), c);
-    const x = sub(newZ, z);
-    if (magnitude(x) < minNumber) {
-      minNumber = magnitude(x);
-      minp = i;
-    }
-    z = newZ;
-  }
-  return minp;
-}
-
-const Wfried = function (c: XYType, l: number, p: number) {
-  const endOfCycle = orbitEigenvalue(c, c, l + p);
-  const startOfCycle = orbitEigenvalue(c, c, l);
-
-  return sub(endOfCycle, startOfCycle);
-};
-
-export const findNearestMisiurewiczPoint = function (c: XYType): XYType {
-  const q = findPotentialPreperiod(c);
-  const p = 1;
-  const learningRate: XYType = [0.01, 0];
-  for (let i = 0; i < 1000; i++) {
-    const F = W(c, q, p);
-    const Fdash = Wfried(c, q, p);
-    c = sub(c, mult(learningRate, divide(F, Fdash)));
-  }
-  return c;
-};
-
-const depthFirstSearch = (z: XYType, c: XYType, zs: XYType[], depth: number) => {
-  zs.push(z);
-  if (distance(z, c) > FLOATING_POINT_TOLERANCE && depth > 0) {
-    depthFirstSearch(preImagePositive(z, c), c, zs, depth - 1);
-    depthFirstSearch(preImageNegative(z, c), c, zs, depth - 1);
-  }
-  return zs;
-};
-
-export const similarPoints = (c: PreperiodicPoint): PreperiodicPoint[] => {
-  const zs: XYType[] = [];
-
-  for (let i = c.prePeriod; i < c.prePeriod + c.period; i++) {
-    const z = orbit(c.point, c.point, i);
-    zs.push(z);
-    depthFirstSearch(mult([-1, 0], z), c.point, zs, MAX_DEPTH);
-  }
-  return zs.map((p) => new PreperiodicPoint(c.point, p));
-};
-
-const subscripts = ['₀', '₁', '₂', '₃', '₄', '₅', '₆', '₇', '₈', '₉'];
-export class PreperiodicPoint {
-  point: XYType;
-  c: XYType;
-  u: XYType;
-  a: XYType;
-  prePeriod: number;
-  period: number;
-  uMagnitude: number;
-  uAngle: number;
-  aMagnitude: number;
-  aAngle: number;
-
-  constructor(c: XYType, z: XYType) {
-    this.point = z;
-    this.c = c;
-
-    this.prePeriod = prePeriod(this.point, c);
-    this.period = period(this.point, c);
-
-    this.u = magnificationRotationMandelbrot(c, this.prePeriod, this.period);
-    this.uMagnitude = magnitude(this.u);
-    this.uAngle = Math.atan2(this.u[1], this.u[0]);
-
-    this.a = magnificationRotationJulia(c, this.point, this.prePeriod);
-    this.aMagnitude = magnitude(this.a);
-    this.aAngle = Math.atan2(this.a[1], this.a[0]);
-  }
-
-  toString(): string {
-    let pre = `M${this.prePeriod},${this.period}`;
-    for (let i = 0; i < 10; i++) {
-      pre = pre.replaceAll(i.toString(), subscripts[i]);
-    }
-    return pre;
-  }
 }

--- a/src/common/settings.ts
+++ b/src/common/settings.ts
@@ -9,6 +9,7 @@ export type settingsDefinitionsType = {
   showCrosshair: boolean;
   showCoordinates: boolean;
   showFPS: boolean;
+  showOrbit: boolean;
   maxI: number;
   useDPR: boolean;
   useAA: boolean;
@@ -21,6 +22,7 @@ export const defaultSettings = {
   showCoordinates: false,
   maxI: 250,
   showFPS: false,
+  showOrbit: false,
   useDPR: false,
   useAA: false,
   colour: defaultShadingColour,

--- a/src/components/orbit_plotter/OrbitCard.tsx
+++ b/src/components/orbit_plotter/OrbitCard.tsx
@@ -1,0 +1,65 @@
+import { Card, Grid, Typography } from '@material-ui/core';
+import React from 'react';
+import { XYType } from '../../common/types';
+import { formatComplexNumber } from '../../common/complex_number_helper';
+
+type OrbitCardProps = {
+  currentPoint: XYType;
+  prePeriod: number;
+  period: number;
+};
+
+const OrbitCard = (props: OrbitCardProps): JSX.Element => {
+  return (
+    <Card
+      style={{
+        width: 'auto',
+        zIndex: 1300,
+        padding: 8,
+        display: 'flex',
+        flexDirection: 'column',
+        position: 'absolute',
+        left: 0,
+        top: 0,
+      }}
+    >
+      <Typography component="span" variant="h6">
+        Orbit for {formatComplexNumber(props.currentPoint)}
+      </Typography>
+      {props.prePeriod !== -1 ? (
+        <>
+          <Grid id="top-row" container spacing={8}>
+            <Grid item xs={4}>
+              <Typography component="span" variant="body1" color="textSecondary">
+                Preperiod
+              </Typography>
+            </Grid>
+            <Grid item xs={4}>
+              <Typography component="span" variant="body1" color="textPrimary">
+                {props.prePeriod}
+              </Typography>
+            </Grid>
+          </Grid>
+          <Grid id="bottom-row" container spacing={8}>
+            <Grid item xs={4}>
+              <Typography component="span" variant="body1" color="textSecondary">
+                Period
+              </Typography>
+            </Grid>
+            <Grid item xs={4}>
+              <Typography component="span" variant="body1" color="textPrimary">
+                {props.period}
+              </Typography>
+            </Grid>
+          </Grid>
+        </>
+      ) : (
+        <Typography component="span" variant="body1" color="textPrimary">
+          divergent
+        </Typography>
+      )}
+    </Card>
+  );
+};
+
+export default OrbitCard;

--- a/src/components/orbit_plotter/OrbitCard.tsx
+++ b/src/components/orbit_plotter/OrbitCard.tsx
@@ -2,6 +2,7 @@ import { Card, Grid, Typography, Grow } from '@material-ui/core';
 import React from 'react';
 import { XYType } from '../../common/types';
 import { formatComplexNumber } from '../../common/complex_number_helper';
+import { MAX_ORBIT_LENGTH } from './OrbitPlotter';
 
 type OrbitCardProps = {
   show: boolean;
@@ -15,14 +16,11 @@ const OrbitCard = (props: OrbitCardProps): JSX.Element => {
     <Grow in={props.show}>
       <Card
         style={{
-          width: 'auto',
-          zIndex: 1300,
-          padding: 8,
-          display: 'flex',
-          flexDirection: 'column',
-          position: 'absolute',
+          position: 'fixed',
           left: 0,
           top: 0,
+          zIndex: 1300,
+          padding: '4px 12px',
         }}
       >
         <Typography component="span" variant="h6">
@@ -30,25 +28,25 @@ const OrbitCard = (props: OrbitCardProps): JSX.Element => {
         </Typography>
         {props.prePeriod !== -1 ? (
           <>
-            <Grid id="top-row" container spacing={8}>
-              <Grid item xs={4}>
+            <Grid id="top-row" container>
+              <Grid item xs>
                 <Typography component="span" variant="body1" color="textSecondary">
                   Preperiod
                 </Typography>
               </Grid>
-              <Grid item xs={4}>
+              <Grid item xs>
                 <Typography component="span" variant="body1" color="textPrimary">
                   {props.prePeriod}
                 </Typography>
               </Grid>
             </Grid>
-            <Grid id="bottom-row" container spacing={8}>
-              <Grid item xs={4}>
+            <Grid id="bottom-row" container>
+              <Grid item xs>
                 <Typography component="span" variant="body1" color="textSecondary">
                   Period
                 </Typography>
               </Grid>
-              <Grid item xs={4}>
+              <Grid item xs>
                 <Typography component="span" variant="body1" color="textPrimary">
                   {props.period}
                 </Typography>
@@ -56,9 +54,11 @@ const OrbitCard = (props: OrbitCardProps): JSX.Element => {
             </Grid>
           </>
         ) : (
-          <Typography component="span" variant="body1" color="textPrimary">
-            divergent
-          </Typography>
+          <Grid id="top-row" container>
+            <Typography component="span" variant="body1" color="textPrimary">
+              Did not reach a cycle after {MAX_ORBIT_LENGTH} iterations
+            </Typography>
+          </Grid>
         )}
       </Card>
     </Grow>

--- a/src/components/orbit_plotter/OrbitCard.tsx
+++ b/src/components/orbit_plotter/OrbitCard.tsx
@@ -1,9 +1,10 @@
-import { Card, Grid, Typography } from '@material-ui/core';
+import { Card, Grid, Typography, Grow } from '@material-ui/core';
 import React from 'react';
 import { XYType } from '../../common/types';
 import { formatComplexNumber } from '../../common/complex_number_helper';
 
 type OrbitCardProps = {
+  show: boolean;
   currentPoint: XYType;
   prePeriod: number;
   period: number;
@@ -11,54 +12,56 @@ type OrbitCardProps = {
 
 const OrbitCard = (props: OrbitCardProps): JSX.Element => {
   return (
-    <Card
-      style={{
-        width: 'auto',
-        zIndex: 1300,
-        padding: 8,
-        display: 'flex',
-        flexDirection: 'column',
-        position: 'absolute',
-        left: 0,
-        top: 0,
-      }}
-    >
-      <Typography component="span" variant="h6">
-        Orbit for {formatComplexNumber(props.currentPoint)}
-      </Typography>
-      {props.prePeriod !== -1 ? (
-        <>
-          <Grid id="top-row" container spacing={8}>
-            <Grid item xs={4}>
-              <Typography component="span" variant="body1" color="textSecondary">
-                Preperiod
-              </Typography>
-            </Grid>
-            <Grid item xs={4}>
-              <Typography component="span" variant="body1" color="textPrimary">
-                {props.prePeriod}
-              </Typography>
-            </Grid>
-          </Grid>
-          <Grid id="bottom-row" container spacing={8}>
-            <Grid item xs={4}>
-              <Typography component="span" variant="body1" color="textSecondary">
-                Period
-              </Typography>
-            </Grid>
-            <Grid item xs={4}>
-              <Typography component="span" variant="body1" color="textPrimary">
-                {props.period}
-              </Typography>
-            </Grid>
-          </Grid>
-        </>
-      ) : (
-        <Typography component="span" variant="body1" color="textPrimary">
-          divergent
+    <Grow in={props.show}>
+      <Card
+        style={{
+          width: 'auto',
+          zIndex: 1300,
+          padding: 8,
+          display: 'flex',
+          flexDirection: 'column',
+          position: 'absolute',
+          left: 0,
+          top: 0,
+        }}
+      >
+        <Typography component="span" variant="h6">
+          Orbit for {formatComplexNumber(props.currentPoint)}
         </Typography>
-      )}
-    </Card>
+        {props.prePeriod !== -1 ? (
+          <>
+            <Grid id="top-row" container spacing={8}>
+              <Grid item xs={4}>
+                <Typography component="span" variant="body1" color="textSecondary">
+                  Preperiod
+                </Typography>
+              </Grid>
+              <Grid item xs={4}>
+                <Typography component="span" variant="body1" color="textPrimary">
+                  {props.prePeriod}
+                </Typography>
+              </Grid>
+            </Grid>
+            <Grid id="bottom-row" container spacing={8}>
+              <Grid item xs={4}>
+                <Typography component="span" variant="body1" color="textSecondary">
+                  Period
+                </Typography>
+              </Grid>
+              <Grid item xs={4}>
+                <Typography component="span" variant="body1" color="textPrimary">
+                  {props.period}
+                </Typography>
+              </Grid>
+            </Grid>
+          </>
+        ) : (
+          <Typography component="span" variant="body1" color="textPrimary">
+            divergent
+          </Typography>
+        )}
+      </Card>
+    </Grow>
   );
 };
 

--- a/src/components/orbit_plotter/OrbitMarker.tsx
+++ b/src/components/orbit_plotter/OrbitMarker.tsx
@@ -30,6 +30,7 @@ type OrbitMarkerProps = {
   point: XYType;
   mandelbrotControl: ViewerControlSprings;
   color: string;
+  show: boolean;
 };
 
 const OrbitMarker = (props: OrbitMarkerProps): JSX.Element => {
@@ -41,6 +42,7 @@ const OrbitMarker = (props: OrbitMarkerProps): JSX.Element => {
   return (
     <FiberManualRecordIcon
       style={{
+        visibility: props.show ? 'visible' : 'hidden',
         zIndex: 100,
         position: 'absolute',
         left:

--- a/src/components/orbit_plotter/OrbitMarker.tsx
+++ b/src/components/orbit_plotter/OrbitMarker.tsx
@@ -1,11 +1,9 @@
 import React from 'react';
-import IconButton from '@material-ui/core/IconButton';
 import { ViewerControlSprings } from '../../common/types';
-import { animated } from 'react-spring';
 import FiberManualRecordIcon from '@material-ui/icons/FiberManualRecord';
 import { XYType } from '../../common/types';
 
-const MARKER_SIZE = 25;
+const MARKER_SIZE = 20;
 
 const complexToScreenCoordinate = (
   x: number,
@@ -41,48 +39,37 @@ const OrbitMarker = (props: OrbitMarkerProps): JSX.Element => {
   const ASPECT_RATIO = props.rendererWidth / props.rendererHeight;
 
   return (
-    <animated.div
+    <FiberManualRecordIcon
       style={{
         zIndex: 100,
         position: 'absolute',
-        left: props.mandelbrotControl.xyCtrl[0].xy.interpolate(
-          // @ts-expect-error: Function call broken in TS, waiting till react-spring v9 to fix
-          (x, y) => {
-            return (
-              complexToScreenCoordinate(
-                x,
-                y,
-                -theta.getValue(),
-                z.getValue(),
-                ASPECT_RATIO,
-                props.rendererHeight,
-                props.point,
-              )[0] - MARKER_SIZE
-            );
-          },
-        ),
-        bottom: props.mandelbrotControl.xyCtrl[0].xy.interpolate(
-          // @ts-expect-error: Function call broken in TS, waiting till react-spring v9 to fix
-          (x, y) => {
-            return (
-              complexToScreenCoordinate(
-                x,
-                y,
-                -theta.getValue(),
-                z.getValue(),
-                ASPECT_RATIO,
-                props.rendererHeight,
-                props.point,
-              )[1] - MARKER_SIZE
-            );
-          },
-        ),
+        left:
+          complexToScreenCoordinate(
+            props.mandelbrotControl.xyCtrl[0].xy.getValue()[0],
+            props.mandelbrotControl.xyCtrl[0].xy.getValue()[1],
+            -theta.getValue(),
+            z.getValue(),
+            ASPECT_RATIO,
+            props.rendererHeight,
+            props.point,
+          )[0] -
+          MARKER_SIZE / 2,
+        bottom:
+          complexToScreenCoordinate(
+            props.mandelbrotControl.xyCtrl[0].xy.getValue()[0],
+            props.mandelbrotControl.xyCtrl[0].xy.getValue()[1],
+            -theta.getValue(),
+            z.getValue(),
+            ASPECT_RATIO,
+            props.rendererHeight,
+            props.point,
+          )[1] -
+          (5 * MARKER_SIZE) / 8,
+        color: props.color,
+        width: MARKER_SIZE,
+        height: MARKER_SIZE,
       }}
-    >
-      <IconButton style={{ color: props.color }}>
-        <FiberManualRecordIcon style={{ width: MARKER_SIZE, height: MARKER_SIZE }} />
-      </IconButton>
-    </animated.div>
+    />
   );
 };
 

--- a/src/components/orbit_plotter/OrbitMarker.tsx
+++ b/src/components/orbit_plotter/OrbitMarker.tsx
@@ -1,8 +1,6 @@
 import React from 'react';
-import { Tooltip } from '@material-ui/core';
 import IconButton from '@material-ui/core/IconButton';
 import { ViewerControlSprings } from '../../common/types';
-import { formatComplexNumber } from '../../common/complex_number_helper';
 import { animated } from 'react-spring';
 import FiberManualRecordIcon from '@material-ui/icons/FiberManualRecord';
 import { XYType } from '../../common/types';
@@ -29,10 +27,9 @@ const complexToScreenCoordinate = (
 };
 
 type OrbitMarkerProps = {
-  show: boolean;
-  mapWidth: number;
-  mapHeight: number;
-  iterate: XYType;
+  rendererWidth: number;
+  rendererHeight: number;
+  point: XYType;
   mandelbrotControl: ViewerControlSprings;
   color: string;
 };
@@ -41,7 +38,7 @@ const OrbitMarker = (props: OrbitMarkerProps): JSX.Element => {
   const [{ z }] = props.mandelbrotControl.zoomCtrl;
   const [{ theta }] = props.mandelbrotControl.rotCtrl;
 
-  const ASPECT_RATIO = props.mapWidth / props.mapHeight;
+  const ASPECT_RATIO = props.rendererWidth / props.rendererHeight;
 
   return (
     <animated.div
@@ -58,8 +55,8 @@ const OrbitMarker = (props: OrbitMarkerProps): JSX.Element => {
                 -theta.getValue(),
                 z.getValue(),
                 ASPECT_RATIO,
-                props.mapHeight,
-                props.iterate,
+                props.rendererHeight,
+                props.point,
               )[0] - MARKER_SIZE
             );
           },
@@ -74,19 +71,17 @@ const OrbitMarker = (props: OrbitMarkerProps): JSX.Element => {
                 -theta.getValue(),
                 z.getValue(),
                 ASPECT_RATIO,
-                props.mapHeight,
-                props.iterate,
+                props.rendererHeight,
+                props.point,
               )[1] - MARKER_SIZE
             );
           },
         ),
       }}
     >
-      <Tooltip title={`${formatComplexNumber(props.iterate)}`} placement="top">
-        <IconButton style={{ color: props.color }}>
-          <FiberManualRecordIcon style={{ width: MARKER_SIZE, height: MARKER_SIZE }} />
-        </IconButton>
-      </Tooltip>
+      <IconButton style={{ color: props.color }}>
+        <FiberManualRecordIcon style={{ width: MARKER_SIZE, height: MARKER_SIZE }} />
+      </IconButton>
     </animated.div>
   );
 };

--- a/src/components/orbit_plotter/OrbitMarker.tsx
+++ b/src/components/orbit_plotter/OrbitMarker.tsx
@@ -1,0 +1,94 @@
+import React from 'react';
+import { Tooltip } from '@material-ui/core';
+import IconButton from '@material-ui/core/IconButton';
+import { ViewerControlSprings } from '../../common/types';
+import { formatComplexNumber } from '../../common/complex_number_helper';
+import { animated } from 'react-spring';
+import FiberManualRecordIcon from '@material-ui/icons/FiberManualRecord';
+import { XYType } from '../../common/types';
+
+const MARKER_SIZE = 25;
+
+const complexToScreenCoordinate = (
+  x: number,
+  y: number,
+  angle: number,
+  zoom: number,
+  boxWidth: number,
+  boxHeight: number,
+  c: XYType,
+): XYType => {
+  const distanceX = c[0] - x;
+  const distanceY = c[1] - y;
+  return [
+    (boxHeight / 2) *
+      ((distanceX * Math.cos(angle) - distanceY * Math.sin(angle)) * zoom + boxWidth),
+    (boxHeight / 2) *
+      ((distanceX * Math.sin(angle) + distanceY * Math.cos(angle)) * zoom + 1),
+  ];
+};
+
+type OrbitMarkerProps = {
+  show: boolean;
+  mapWidth: number;
+  mapHeight: number;
+  iterate: XYType;
+  mandelbrotControl: ViewerControlSprings;
+  color: string;
+};
+
+const OrbitMarker = (props: OrbitMarkerProps): JSX.Element => {
+  const [{ z }] = props.mandelbrotControl.zoomCtrl;
+  const [{ theta }] = props.mandelbrotControl.rotCtrl;
+
+  const ASPECT_RATIO = props.mapWidth / props.mapHeight;
+
+  return (
+    <animated.div
+      style={{
+        zIndex: 100,
+        position: 'absolute',
+        left: props.mandelbrotControl.xyCtrl[0].xy.interpolate(
+          // @ts-expect-error: Function call broken in TS, waiting till react-spring v9 to fix
+          (x, y) => {
+            return (
+              complexToScreenCoordinate(
+                x,
+                y,
+                -theta.getValue(),
+                z.getValue(),
+                ASPECT_RATIO,
+                props.mapHeight,
+                props.iterate,
+              )[0] - MARKER_SIZE
+            );
+          },
+        ),
+        bottom: props.mandelbrotControl.xyCtrl[0].xy.interpolate(
+          // @ts-expect-error: Function call broken in TS, waiting till react-spring v9 to fix
+          (x, y) => {
+            return (
+              complexToScreenCoordinate(
+                x,
+                y,
+                -theta.getValue(),
+                z.getValue(),
+                ASPECT_RATIO,
+                props.mapHeight,
+                props.iterate,
+              )[1] - MARKER_SIZE
+            );
+          },
+        ),
+      }}
+    >
+      <Tooltip title={`${formatComplexNumber(props.iterate)}`} placement="top">
+        <IconButton style={{ color: props.color }}>
+          <FiberManualRecordIcon style={{ width: MARKER_SIZE, height: MARKER_SIZE }} />
+        </IconButton>
+      </Tooltip>
+    </animated.div>
+  );
+};
+
+export default OrbitMarker;

--- a/src/components/orbit_plotter/OrbitPlotter.tsx
+++ b/src/components/orbit_plotter/OrbitPlotter.tsx
@@ -47,7 +47,7 @@ const withinBoundBox = (
   return horizontalDistance < boxWidth && verticalDistance < boxHeight;
 };
 
-export const MAX_ORBIT_LENGTH = 20;
+export const MAX_ORBIT_LENGTH = 70;
 const ORBIT_REFRESH_TIME = 50;
 
 const COLOUR_PERIODIC = '#EE0000';
@@ -73,27 +73,25 @@ export class OrbitPlotter extends Component<OrbitPlotterProps, OrbitManagerState
     );
 
     const aspect_ratio = this.props.rendererWidth / this.props.rendererHeight;
-    const visiblePoints: XYType[] = orbit.filter((x) =>
-      withinBoundBox(
-        x,
-        this.props.mandelbrot.xyCtrl[0].xy.getValue(),
-        aspect_ratio / this.props.mandelbrot.zoomCtrl[0].z.getValue(),
-        1 / this.props.mandelbrot.zoomCtrl[0].z.getValue(),
-        -this.props.mandelbrot.rotCtrl[0].theta.getValue(),
-      ),
-    );
 
     const orbitMarkers: JSX.Element[] = [];
-    for (let i = 0; i < visiblePoints.length; i++) {
+    for (let i = 0; i < orbit.length; i++) {
       const color = i + 1 > orbit.length - period ? COLOUR_PERIODIC : COLOUR_PREPERIODIC;
       orbitMarkers.push(
         <OrbitMarker
-          key={visiblePoints[i].toString()}
-          point={visiblePoints[i]}
+          key={orbit[i].toString()}
+          point={orbit[i]}
           rendererWidth={this.props.rendererWidth}
           rendererHeight={this.props.rendererHeight}
           mandelbrotControl={this.props.mandelbrot}
           color={color}
+          show={withinBoundBox(
+            orbit[i],
+            this.props.mandelbrot.xyCtrl[0].xy.getValue(),
+            aspect_ratio / this.props.mandelbrot.zoomCtrl[0].z.getValue(),
+            1 / this.props.mandelbrot.zoomCtrl[0].z.getValue(),
+            -this.props.mandelbrot.rotCtrl[0].theta.getValue(),
+          )}
         />,
       );
     }

--- a/src/components/orbit_plotter/OrbitPlotter.tsx
+++ b/src/components/orbit_plotter/OrbitPlotter.tsx
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { orbitList } from '../../common/complex_number_helper';
+import { forwardOrbit } from '../../common/complex_number_helper';
 import { ViewerControlSprings, XYType } from '../../common/types';
 import OrbitCard from './OrbitCard';
 import OrbitMarker from './OrbitMarker';
@@ -8,7 +8,7 @@ type OrbitManagerState = {
   currentPoint: XYType;
   period: number;
   prePeriod: number;
-  orbitPoints: JSX.Element[];
+  orbitMarkers: JSX.Element[];
 };
 
 type OrbitPlotterProps = {
@@ -18,83 +18,97 @@ type OrbitPlotterProps = {
   rendererHeight: number;
 };
 
+/**
+ * Check if a point is within a given "bounding" box.
+ *
+ * @param {p} A point.
+ * @param {boxCentre} The centre of the box.
+ * @param {boxWidth} The width of the box.
+ * @param {boxHeight} The height of the box.
+ * @param {boxAngle} The angle the box makes with the x-axis.
+ */
 const withinBoundBox = (
   p: XYType,
   boxCentre: XYType,
   boxWidth: number,
   boxHeight: number,
-  angleRelativeToBox: number,
+  boxAngle: number,
 ): boolean => {
   const distanceX = p[0] - boxCentre[0];
   const distanceY = p[1] - boxCentre[1];
 
   const horizontalDistance: number = Math.abs(
-    distanceX * Math.cos(angleRelativeToBox) - distanceY * Math.sin(angleRelativeToBox),
+    distanceX * Math.cos(-boxAngle) - distanceY * Math.sin(-boxAngle),
   );
   const verticalDistance: number = Math.abs(
-    distanceX * Math.sin(angleRelativeToBox) + distanceY * Math.cos(angleRelativeToBox),
+    distanceX * Math.sin(-boxAngle) + distanceY * Math.cos(-boxAngle),
   );
 
   return horizontalDistance < boxWidth && verticalDistance < boxHeight;
 };
 
+export const MAX_ORBIT_LENGTH = 20;
+const ORBIT_REFRESH_TIME = 50;
+
 const COLOUR_PERIODIC = '#EE0000';
 const COLOUR_PREPERIODIC = '#EEEE00';
 
 export class OrbitPlotter extends Component<OrbitPlotterProps, OrbitManagerState> {
-  tick() {
-    const ASPECT_RATIO = this.props.rendererWidth / this.props.rendererHeight;
-    const orbitInformation = orbitList(
+  constructor(props: OrbitPlotterProps) {
+    super(props);
+    this.state = {
+      currentPoint: [0, 0],
+      prePeriod: -1,
+      period: -1,
+      orbitMarkers: [],
+    };
+    setInterval(() => this.tick(), ORBIT_REFRESH_TIME);
+  }
+
+  tick(): void {
+    const [orbit, prePeriod, period] = forwardOrbit(
       this.props.mandelbrot.xyCtrl[0].xy.getValue(),
       this.props.mandelbrot.xyCtrl[0].xy.getValue(),
-      20,
+      MAX_ORBIT_LENGTH,
     );
-    const orbitPs = orbitInformation[0].filter((x) =>
+
+    const aspect_ratio = this.props.rendererWidth / this.props.rendererHeight;
+    const visiblePoints: XYType[] = orbit.filter((x) =>
       withinBoundBox(
         x,
         this.props.mandelbrot.xyCtrl[0].xy.getValue(),
-        ASPECT_RATIO / this.props.mandelbrot.zoomCtrl[0].z.getValue(),
+        aspect_ratio / this.props.mandelbrot.zoomCtrl[0].z.getValue(),
         1 / this.props.mandelbrot.zoomCtrl[0].z.getValue(),
         -this.props.mandelbrot.rotCtrl[0].theta.getValue(),
       ),
     );
+
+    const orbitMarkers: JSX.Element[] = [];
+    for (let i = 0; i < visiblePoints.length; i++) {
+      const color = i + 1 > orbit.length - period ? COLOUR_PERIODIC : COLOUR_PREPERIODIC;
+      orbitMarkers.push(
+        <OrbitMarker
+          key={visiblePoints[i].toString()}
+          point={visiblePoints[i]}
+          rendererWidth={this.props.rendererWidth}
+          rendererHeight={this.props.rendererHeight}
+          mandelbrotControl={this.props.mandelbrot}
+          color={color}
+        />,
+      );
+    }
     this.setState({
       currentPoint: this.props.mandelbrot.xyCtrl[0].xy.getValue(),
-      prePeriod: orbitInformation[1],
-      period: orbitInformation[2],
-      orbitPoints: [...Array(orbitPs.length).keys()].map((i) => {
-        const p = orbitPs[i];
-        const color =
-          i + 1 > orbitPs.length - orbitInformation[2]
-            ? COLOUR_PERIODIC
-            : COLOUR_PREPERIODIC;
-        return (
-          <OrbitMarker
-            key={p.toString()}
-            iterate={p}
-            mapWidth={this.props.rendererWidth}
-            mapHeight={this.props.rendererHeight}
-            show={true}
-            mandelbrotControl={this.props.mandelbrot}
-            color={color}
-          />
-        );
-      }),
+      prePeriod: prePeriod,
+      period: period,
+      orbitMarkers: orbitMarkers,
     });
   }
 
-  UNSAFE_componentWillMount() {
-    this.tick();
-  }
-
-  componentDidMount() {
-    setInterval(() => this.tick(), 100);
-  }
-
-  render() {
+  render(): JSX.Element {
     return (
       <>
-        {this.props.show ? this.state.orbitPoints : null}
+        {this.props.show ? this.state.orbitMarkers : null}
         <OrbitCard
           show={this.props.show}
           currentPoint={this.state.currentPoint}

--- a/src/components/orbit_plotter/OrbitPlotter.tsx
+++ b/src/components/orbit_plotter/OrbitPlotter.tsx
@@ -1,0 +1,107 @@
+import React, { Component } from 'react';
+import { orbitList } from '../../common/complex_number_helper';
+import { ViewerControlSprings, XYType } from '../../common/types';
+import OrbitCard from './OrbitCard';
+import OrbitMarker from './OrbitMarker';
+
+type OrbitManagerState = {
+  currentPoint: XYType;
+  period: number;
+  prePeriod: number;
+  orbitPoints: JSX.Element[];
+};
+
+type OrbitPlotterProps = {
+  mandelbrot: ViewerControlSprings;
+  mapWidth: number;
+  mapHeight: number;
+};
+
+const withinBoundBox = (
+  p: XYType,
+  boxCentre: XYType,
+  boxWidth: number,
+  boxHeight: number,
+  angleRelativeToBox: number,
+): boolean => {
+  const distanceX = p[0] - boxCentre[0];
+  const distanceY = p[1] - boxCentre[1];
+
+  const horizontalDistance: number = Math.abs(
+    distanceX * Math.cos(angleRelativeToBox) - distanceY * Math.sin(angleRelativeToBox),
+  );
+  const verticalDistance: number = Math.abs(
+    distanceX * Math.sin(angleRelativeToBox) + distanceY * Math.cos(angleRelativeToBox),
+  );
+
+  return horizontalDistance < boxWidth && verticalDistance < boxHeight;
+};
+
+const COLOUR_PERIODIC = '#EE0000';
+const COLOUR_PREPERIODIC = '#EEEE00';
+
+export class OrbitPlotter extends Component<OrbitPlotterProps, OrbitManagerState> {
+  tick() {
+    const ASPECT_RATIO = this.props.mapWidth / this.props.mapHeight;
+    const orbitInformation = orbitList(
+      this.props.mandelbrot.xyCtrl[0].xy.getValue(),
+      this.props.mandelbrot.xyCtrl[0].xy.getValue(),
+      20,
+    );
+    const orbitPs = orbitInformation[0].filter((x) =>
+      withinBoundBox(
+        x,
+        this.props.mandelbrot.xyCtrl[0].xy.getValue(),
+        ASPECT_RATIO / this.props.mandelbrot.zoomCtrl[0].z.getValue(),
+        1 / this.props.mandelbrot.zoomCtrl[0].z.getValue(),
+        -this.props.mandelbrot.rotCtrl[0].theta.getValue(),
+      ),
+    );
+    this.setState({
+      currentPoint: this.props.mandelbrot.xyCtrl[0].xy.getValue(),
+      prePeriod: orbitInformation[1],
+      period: orbitInformation[2],
+      orbitPoints: [...Array(orbitPs.length).keys()].map((i) => {
+        const p = orbitPs[i];
+        const color =
+          i + 1 > orbitPs.length - orbitInformation[2]
+            ? COLOUR_PERIODIC
+            : COLOUR_PREPERIODIC;
+        return (
+          <OrbitMarker
+            key={p.toString()}
+            iterate={p}
+            mapWidth={this.props.mapWidth}
+            mapHeight={this.props.mapHeight}
+            show={true}
+            mandelbrotControl={this.props.mandelbrot}
+            color={color}
+          />
+        );
+      }),
+    });
+  }
+
+  UNSAFE_componentWillMount() {
+    this.tick();
+  }
+
+  componentDidMount() {
+    setInterval(() => this.tick(), 100);
+  }
+
+  render() {
+    return (
+      <>
+        {this.state.orbitPoints}
+        <OrbitCard
+          currentPoint={this.state.currentPoint}
+          prePeriod={this.state.prePeriod}
+          period={this.state.period}
+        />
+      </>
+    );
+  }
+}
+
+export default OrbitPlotter;

--- a/src/components/orbit_plotter/OrbitPlotter.tsx
+++ b/src/components/orbit_plotter/OrbitPlotter.tsx
@@ -12,9 +12,10 @@ type OrbitManagerState = {
 };
 
 type OrbitPlotterProps = {
+  show: boolean;
   mandelbrot: ViewerControlSprings;
-  mapWidth: number;
-  mapHeight: number;
+  rendererWidth: number;
+  rendererHeight: number;
 };
 
 const withinBoundBox = (
@@ -42,7 +43,7 @@ const COLOUR_PREPERIODIC = '#EEEE00';
 
 export class OrbitPlotter extends Component<OrbitPlotterProps, OrbitManagerState> {
   tick() {
-    const ASPECT_RATIO = this.props.mapWidth / this.props.mapHeight;
+    const ASPECT_RATIO = this.props.rendererWidth / this.props.rendererHeight;
     const orbitInformation = orbitList(
       this.props.mandelbrot.xyCtrl[0].xy.getValue(),
       this.props.mandelbrot.xyCtrl[0].xy.getValue(),
@@ -71,8 +72,8 @@ export class OrbitPlotter extends Component<OrbitPlotterProps, OrbitManagerState
           <OrbitMarker
             key={p.toString()}
             iterate={p}
-            mapWidth={this.props.mapWidth}
-            mapHeight={this.props.mapHeight}
+            mapWidth={this.props.rendererWidth}
+            mapHeight={this.props.rendererHeight}
             show={true}
             mandelbrotControl={this.props.mandelbrot}
             color={color}
@@ -93,8 +94,9 @@ export class OrbitPlotter extends Component<OrbitPlotterProps, OrbitManagerState
   render() {
     return (
       <>
-        {this.state.orbitPoints}
+        {this.props.show ? this.state.orbitPoints : null}
         <OrbitCard
+          show={this.props.show}
           currentPoint={this.state.currentPoint}
           prePeriod={this.state.prePeriod}
           period={this.state.period}

--- a/src/components/settings/SettingsDefinitions.tsx
+++ b/src/components/settings/SettingsDefinitions.tsx
@@ -73,6 +73,11 @@ export const settingsWidgets = (
     checked: settings.showFPS,
     control: <Switch />,
   },
+  showOrbit: {
+    label: `Show orbit`,
+    checked: settings.showOrbit,
+    control: <Switch />,
+  },
   colour: {
     label: null,
     style: {
@@ -100,6 +105,7 @@ export const getSettingsWidgetsGrouping = (
       showMinimap: settingsWidgets.showMinimap,
       showCrosshair: settingsWidgets.showCrosshair,
       showCoordinates: settingsWidgets.showCoordinates,
+      showOrbit: settingsWidgets.showOrbit,
     },
     // ],
   },

--- a/src/components/settings/SettingsMenu.tsx
+++ b/src/components/settings/SettingsMenu.tsx
@@ -73,6 +73,7 @@ export default function SettingsMenu(props: SettingsMenuProps): JSX.Element {
       color="secondary"
       aria-controls="reset"
       onClick={() => {
+        // eslint-disable-next-line react/prop-types
         props.reset();
       }}
     >
@@ -85,6 +86,7 @@ export default function SettingsMenu(props: SettingsMenuProps): JSX.Element {
       color="primary"
       aria-controls="about"
       onClick={() => {
+        // eslint-disable-next-line react/prop-types
         props.toggleInfo();
         setAnchorEl(undefined);
       }}


### PR DESCRIPTION
## What
This PR adds an orbit plotter to Mandelbrot Maps. When toggled in the settings menu, small yellow dots indicate the orbit from the user's current position. If the orbit reaches a cycle, the cyclic points are indicated in red.
## Toggling the orbit plotter
![image](https://user-images.githubusercontent.com/29184158/106477821-7840f500-64a0-11eb-97c8-671307426977.png)
## An orbit
![image](https://user-images.githubusercontent.com/29184158/106478184-dc63b900-64a0-11eb-8a38-5069fa2ba167.png)
## A cyclic orbit
![image](https://user-images.githubusercontent.com/29184158/106478238-e71e4e00-64a0-11eb-8cb8-84096cd57f6c.png)

## Performance problems (fixed now, ignore this)
Most of the interesting stuff happens in the new **OrbitPlotter** component. It maintains a list of **OrbitMarkers**, each of which is an `animated.div` corresponding to a particular complex number. Their positions on the screen are calculated whenever the user moves, by translating their complex number coordinate to a screen coordinate. This DOES NOT update the points _in_ the orbit or the length of the orbit, just their individual, relative positions on the screen.

To update the orbit itself, **OrbitPlotter** has a timer that "ticks" every few milliseconds. Upon each tick, a new set of markers are generated to reflect the orbit from the users current position. This is a workaround to the following: I simply cannot find a way to update an array every time the users position changes.

It seems a little odd that I'm using both movement-based updating and time-based updating, but hey. As we have to calculate the orbit and the positions of the HTML markers every few milliseconds, the orbit plotter is quite slow. I'm very interested in ways to get around this!

The time slice and the maximum orbit length are constants that can be tweaked to decrease computations.